### PR TITLE
Remove dependency on deprecated registry

### DIFF
--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -34,7 +34,6 @@
     "@saberhq/anchor-contrib": "1.13.32",
     "@solana/buffer-layout": "^4.0.0",
     "@solana/spl-token": "0.1.8",
-    "@solana/spl-token-registry": "0.2.1105",
     "@solana/web3.js": "~1.72.0",
     "bn.js": "5.2.1",
     "cross-fetch": "^3.1.5",

--- a/ts-client/pnpm-lock.yaml
+++ b/ts-client/pnpm-lock.yaml
@@ -59,9 +59,6 @@ dependencies:
   '@solana/spl-token':
     specifier: 0.1.8
     version: 0.1.8
-  '@solana/spl-token-registry':
-    specifier: 0.2.1105
-    version: 0.2.1105
   '@solana/web3.js':
     specifier: ~1.72.0
     version: 1.72.0
@@ -1611,13 +1608,6 @@ packages:
     engines: {node: '>=5.10'}
     dependencies:
       buffer: 6.0.3
-
-  /@solana/spl-token-registry@0.2.1105:
-    resolution: {integrity: sha512-s9MIUoTAtqYsg1RaXIHXq7DhsUVS9VckvrwYuJBFn68YCZNSMUEquqaimbaHi88OVduFsApVAbKRmsGnJ9abIw==}
-    engines: {node: '>=10'}
-    dependencies:
-      cross-fetch: 3.0.6
-    dev: false
 
   /@solana/spl-token-registry@0.2.3988:
     resolution: {integrity: sha512-Y+8JbpiNWNkEgeXjGjAWA13qrf0YJZULmCR/MPL8tkqLF8uHDvJvOHFe9lzfqDvIzAO8dTdz2CMa2e+TeEjjuQ==}

--- a/ts-client/src/vault/index.ts
+++ b/ts-client/src/vault/index.ts
@@ -9,9 +9,8 @@ import {
   SystemProgram,
 } from '@solana/web3.js';
 import { MintLayout, TOKEN_PROGRAM_ID, u64, NATIVE_MINT } from '@solana/spl-token';
-import { TokenInfo } from '@solana/spl-token-registry';
 
-import { AffiliateInfo, AffiliateVaultProgram, VaultImplementation, VaultProgram, VaultState } from './types';
+import { AffiliateInfo, AffiliateVaultProgram, TokenInfo, VaultImplementation, VaultProgram, VaultState } from './types';
 import {
   chunkedFetchMultipleVaultAccount,
   chunkedGetMultipleAccountInfos,

--- a/ts-client/src/vault/strategy/index.ts
+++ b/ts-client/src/vault/strategy/index.ts
@@ -1,6 +1,5 @@
 import { BN } from '@project-serum/anchor';
 import { Cluster, PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
-import { TokenInfo } from '@solana/spl-token-registry';
 
 import { StrategyProgram } from '../constants';
 import type { AffiliateVaultProgram, VaultProgram, VaultState } from '../types';

--- a/ts-client/src/vault/tests/affiliate.test.ts
+++ b/ts-client/src/vault/tests/affiliate.test.ts
@@ -1,21 +1,27 @@
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
-import { StaticTokenListResolutionStrategy, TokenInfo } from '@solana/spl-token-registry';
 import { Wallet, AnchorProvider, BN } from '@project-serum/anchor';
 
 import VaultImpl from '..';
-import { airDropSol } from './utils';
+import { airDropSol, getValidatedTokens } from './utils';
+import { TokenInfo } from '../types';
 
 const mockWallet = new Wallet(new Keypair());
 // devnet ATA creation and reading must use confirmed.
 const devnetConnection = new Connection('https://api.devnet.solana.com/', { commitment: 'confirmed' });
 
-const tokenMap = new StaticTokenListResolutionStrategy().resolve();
-const SOL_TOKEN_INFO = tokenMap.find((token) => token.symbol === 'SOL') as TokenInfo;
-const USDC_TOKEN_INFO = tokenMap.find((token) => token.symbol === 'USDC') as TokenInfo;
-const USDT_TOKEN_INFO = tokenMap.find((token) => token.symbol === 'USDT') as TokenInfo;
-
 // TODO: Remove this fake partner ID
 const TEMPORARY_PARTNER_PUBLIC_KEY = new PublicKey('7236FoaWTXJyzbfFPZcrzg3tBpPhGiTgXsGWvjwrYfiF');
+
+let SOL_TOKEN_INFO: TokenInfo;
+let USDC_TOKEN_INFO: TokenInfo;
+let USDT_TOKEN_INFO: TokenInfo;
+
+beforeAll(async () => {
+  const tokenList = await getValidatedTokens();
+  SOL_TOKEN_INFO = tokenList.find(token => token.symbol === 'SOL') as TokenInfo;
+  USDC_TOKEN_INFO = tokenList.find(token => token.symbol === 'USDC') as TokenInfo;
+  USDT_TOKEN_INFO = tokenList.find(token => token.symbol === 'USDT') as TokenInfo;
+});
 describe('Interact with Vault in devnet', () => {
   const provider = new AnchorProvider(devnetConnection, mockWallet, {
     commitment: 'confirmed',

--- a/ts-client/src/vault/tests/utils/index.ts
+++ b/ts-client/src/vault/tests/utils/index.ts
@@ -1,4 +1,5 @@
 import { Connection, PublicKey } from '@solana/web3.js';
+import { TokenInfo } from '../../types';
 
 const LAMPORTS_PER_SOL = 1e9;
 export const airDropSol = async (connection: Connection, publicKey: PublicKey, amount = 1 * LAMPORTS_PER_SOL) => {
@@ -13,5 +14,19 @@ export const airDropSol = async (connection: Connection, publicKey: PublicKey, a
   } catch (error) {
     console.error(error);
     throw error;
+  }
+};
+
+export async function getValidatedTokens(): Promise<TokenInfo[]> {
+  try {
+    const tokensList: TokenInfo[] = [];
+    const data = await fetch(`https://token.jup.ag/strict`)
+    const tokens = await data.json()
+    tokens.forEach((token: TokenInfo) => {
+      tokensList.push(token);
+    });
+    return tokensList;
+  } catch (error: any) {
+    throw new Error("Failed to fetch validated tokens");
   }
 };

--- a/ts-client/src/vault/tests/vault.test.ts
+++ b/ts-client/src/vault/tests/vault.test.ts
@@ -1,27 +1,32 @@
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
-import { StaticTokenListResolutionStrategy, TokenInfo } from '@solana/spl-token-registry';
 import { Wallet, AnchorProvider, BN } from '@project-serum/anchor';
 
 import VaultImpl from '..';
-import { airDropSol } from './utils';
+import { airDropSol, getValidatedTokens } from './utils';
 import { getVaultPdas } from '../utils';
 import { PROGRAM_ID } from '../constants';
+import { TokenInfo } from '../types';
 
 const mockWallet = new Wallet(new Keypair());
 const mainnetConnection = new Connection('https://api.mainnet-beta.solana.com');
 // devnet ATA creation and reading must use confirmed.
 const devnetConnection = new Connection('https://api.devnet.solana.com/', { commitment: 'confirmed' });
 
-// Prevent importing directly from .json, causing slowdown on Intellisense
-const tokenMap = new StaticTokenListResolutionStrategy().resolve();
-const SOL_TOKEN_INFO = tokenMap.find((token) => token.symbol === 'SOL') as TokenInfo;
-const USDC_TOKEN_INFO = tokenMap.find((token) => token.symbol === 'USDC') as TokenInfo;
-const USDT_TOKEN_INFO = tokenMap.find((token) => token.symbol === 'USDT') as TokenInfo;
+let SOL_TOKEN_INFO: TokenInfo;
+let USDC_TOKEN_INFO: TokenInfo;
+let USDT_TOKEN_INFO: TokenInfo;
+
+beforeAll(async () => {
+  const tokenList = await getValidatedTokens();
+  SOL_TOKEN_INFO = tokenList.find(token => token.symbol === 'SOL') as TokenInfo;
+  USDC_TOKEN_INFO = tokenList.find(token => token.symbol === 'USDC') as TokenInfo;
+  USDT_TOKEN_INFO = tokenList.find(token => token.symbol === 'USDT') as TokenInfo;
+});
 
 describe('Get Mainnet vault state', () => {
   let vaults: VaultImpl[] = [];
   let vaultsForPool: VaultImpl[] = [];
-
+  
   // Make sure all vaults can be initialized
   beforeAll(async () => {
     const tokensInfo = [SOL_TOKEN_INFO, USDC_TOKEN_INFO, USDT_TOKEN_INFO];

--- a/ts-client/src/vault/types/index.ts
+++ b/ts-client/src/vault/types/index.ts
@@ -43,3 +43,11 @@ export interface ParsedClockState {
   program: string;
   space: number;
 }
+
+export interface TokenInfo {
+  address: string;
+  decimals: number;
+  name: string;
+  symbol: string;
+  logoURI?: string;
+};


### PR DESCRIPTION
SPL-Token registry is now deprecated but it is now a dependency to be passed into the vault program. This PR addresses removing it but open to suggestions. 

Should just ignore the type and use `string` for the tokenInfo parameter since only the `address` is ever checked when interacting with the program. The type can be moved to the test folder to keep the test functionality the same. 