### PR TITLE
fix mainnet-beta url

### DIFF
--- a/ts-client/src/vault/constants.ts
+++ b/ts-client/src/vault/constants.ts
@@ -59,7 +59,7 @@ export const StrategyProgram: Record<
 export const KEEPER_URL: Record<Cluster, string> = {
   testnet: 'https://staging-keeper.raccoons.dev',
   devnet: 'https://dev-keeper.raccoons.dev',
-  'mainnet-beta': 'https://merv2-api.mercurial.finance',
+  'mainnet-beta': 'https://merv2-api.meteora.ag',
 };
 
 export const VAULT_STRATEGY_ADDRESS = '11111111111111111111111111111111';


### PR DESCRIPTION
This URL is a 404: https://merv2-api.mercurial.finance/vault-info

The correct URL is: https://merv2-api.meteora.ag/vault-info